### PR TITLE
Add mybinder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Instructors: John Stachurski and Natasha Watkins
 
 Homepage: https://quantecon.org/copenhagen-summer-school-2018
 
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/QuantEcon/Copenhagen_workshop_2018/master)
+
 
 **Schedule**
 

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,2 @@
+gfortran
+htop

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+dependencies:
+  - anaconda
+  - numba=0.38
+  - quantecon

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,4 @@ dependencies:
   - anaconda
   - numba=0.38
   - quantecon
+  - sklearn

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ dependencies:
   - anaconda
   - numba=0.38
   - quantecon
-  - sklearn
+  - scikit-learn


### PR DESCRIPTION
This PR adds mybinder support including:

- anaconda
- scikit-learn
- quantecon
- numba=0.38

and includes `gfortran` and `htop`

It also includes a badge in the README but it will only work once the PR has merged as I have directed to link to the `master` branch.